### PR TITLE
fix(datacollector): 添加 jsonc-parser 依赖并优化配置解析,修复settings.json中的注释解析失败的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,5 +168,8 @@
     "prettier": "3.6.2",
     "typescript": "^5.8.3"
   },
-  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a"
+  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a",
+  "dependencies": {
+    "jsonc-parser": "^3.3.1"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
     devDependencies:
       '@types/mocha':
         specifier: ^10.0.10

--- a/src/dataCollector.ts
+++ b/src/dataCollector.ts
@@ -17,6 +17,7 @@ import {
   getPlatform,
 } from './utils/vscodeEnvironment';
 import { VSCodeEdition, Platform } from './types/vscodeEdition';
+import * as jsonc from 'jsonc-parser';
 
 export class DataCollector {
   public readonly vscodeEdition: VSCodeEdition;
@@ -101,7 +102,6 @@ export class DataCollector {
   }
 
   async getSettings(): Promise<SettingsExport> {
-    const config = vscode.workspace.getConfiguration();
     const settings: SettingsExport = {};
 
     // 获取用户设置
@@ -220,7 +220,7 @@ export class DataCollector {
       const settingsPath = this.getUserSettingsPath();
       if (fs.existsSync(settingsPath)) {
         const content = fs.readFileSync(settingsPath, 'utf8');
-        return JSON.parse(content);
+        return jsonc.parse(content);
       }
     } catch (error) {
       if (this.outputChannel) {
@@ -237,7 +237,7 @@ export class DataCollector {
         const settingsPath = path.join(workspaceFolder.uri.fsPath, '.vscode', 'settings.json');
         if (fs.existsSync(settingsPath)) {
           const content = fs.readFileSync(settingsPath, 'utf8');
-          return JSON.parse(content);
+          return jsonc.parse(content);
         }
       }
     } catch (error) {


### PR DESCRIPTION
- 在 package.json 中添加 jsonc-parser 依赖
- 更新 pnpm-lock.yaml 文件以反映新依赖
- 修改 dataCollector.ts 中的配置解析逻辑，使用 jsonc-parser 替代原生 JSON.parse