### PR TITLE
ci(release): 允许更新已存在的 GitHub 发布版本

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -45,3 +45,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.version.outputs.version }}
           name: Release ${{ steps.version.outputs.version }}
+          allowUpdates: true


### PR DESCRIPTION
- 在 GitHub 发布工作流程中添加 allowUpdates 参数
- 设置 allowUpdates 为 true，允许更新已存在的发布版本