### PR TITLE
fix: 移除 activationEvents 空数组

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [


### PR DESCRIPTION
- 删除 package.json 里的 "activationEvents": [] 。 由于vscode为所有命令生成激活事件