### PR TITLE
fix(esbuild): 修复引入外部依赖时pnpm构建异常的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-syncing",
   "displayName": "vscode-syncing",
   "description": "vscode-syncing extension",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "sunerpy",
   "icon": "resources/logo.png",
   "engines": {
@@ -124,12 +124,13 @@
     "prepare": "husky",
     "lint": "eslint src",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "vscode:prepublish": "pnpm run package",
+    "vscode:prepublish": "npm run esbuild-base -- --minify",
+    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
     "compile": "pnpm run check-types && pnpm run lint && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
-    "package": "pnpm run check-types && pnpm run lint && node esbuild.js --production",
+    "package": "pnpm run vscode:prepublish",
     "package:vsix": "pnpm run package && pnpm vsce package --no-dependencies",
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",
@@ -167,8 +168,5 @@
     "prettier": "3.6.2",
     "typescript": "^5.8.3"
   },
-  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a",
-  "dependencies": {
-    "jsonc-parser": "^3.3.1"
-  }
+  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a"
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      jsonc-parser:
-        specifier: ^3.3.1
-        version: 3.3.1
     devDependencies:
       '@types/mocha':
         specifier: ^10.0.10

--- a/src/dataCollector.ts
+++ b/src/dataCollector.ts
@@ -17,7 +17,6 @@ import {
   getPlatform,
 } from './utils/vscodeEnvironment';
 import { VSCodeEdition, Platform } from './types/vscodeEdition';
-import * as jsonc from 'jsonc-parser';
 
 export class DataCollector {
   public readonly vscodeEdition: VSCodeEdition;
@@ -107,13 +106,13 @@ export class DataCollector {
     // 获取用户设置
     const userSettings = this.getUserSettings();
     if (userSettings) {
-      settings.user = userSettings;
+      (settings as any).user = userSettings;
     }
 
     // 获取工作区设置
     const workspaceSettings = this.getWorkspaceSettings();
     if (workspaceSettings) {
-      settings.workspace = workspaceSettings;
+      (settings as any).workspace = workspaceSettings;
     }
 
     return settings;
@@ -215,12 +214,11 @@ export class DataCollector {
     return snippets;
   }
 
-  private getUserSettings(): Record<string, unknown> | null {
+  private getUserSettings(): string | null {
     try {
       const settingsPath = this.getUserSettingsPath();
       if (fs.existsSync(settingsPath)) {
-        const content = fs.readFileSync(settingsPath, 'utf8');
-        return jsonc.parse(content);
+        return fs.readFileSync(settingsPath, 'utf8');
       }
     } catch (error) {
       if (this.outputChannel) {
@@ -230,14 +228,13 @@ export class DataCollector {
     return null;
   }
 
-  private getWorkspaceSettings(): Record<string, unknown> | null {
+  private getWorkspaceSettings(): string | null {
     try {
       if (vscode.workspace.workspaceFolders) {
         const workspaceFolder = vscode.workspace.workspaceFolders[0];
         const settingsPath = path.join(workspaceFolder.uri.fsPath, '.vscode', 'settings.json');
         if (fs.existsSync(settingsPath)) {
-          const content = fs.readFileSync(settingsPath, 'utf8');
-          return jsonc.parse(content);
+          return fs.readFileSync(settingsPath, 'utf8');
         }
       }
     } catch (error) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -24,8 +24,8 @@ export interface ExtensionsExport {
 }
 
 export interface SettingsExport {
-  user?: Record<string, unknown>;
-  workspace?: Record<string, unknown>;
+  user?: string;
+  workspace?: string;
 }
 
 export interface ThemeInfo {


### PR DESCRIPTION
fix(esbuild): 修复引入外部依赖时pnpm构建异常的问题

- 修改了 DataCollector 类中获取用户设置和工作区设置的方式，直接返回字符串内容
- 更新了 SettingsExport 接口，将 user 和 workspace 的类型改为 string